### PR TITLE
Fix sorting issues on test InfinispanGraphQLQueryOrderByIT.testJobsSort

### DIFF
--- a/data-index/data-index-storage/data-index-storage-protobuf/src/main/resources/META-INF/kogito-index.proto
+++ b/data-index/data-index-storage/data-index-storage-protobuf/src/main/resources/META-INF/kogito-index.proto
@@ -127,7 +127,9 @@ message UserTaskInstance {
     optional string rootProcessInstanceId = 7;
     /* @Field(store = Store.YES) */
     optional string rootProcessId = 8;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string state = 9;
     /* @Field(store = Store.YES) */
     optional string actualOwner = 10;
@@ -190,29 +192,49 @@ message UserTaskInstanceMeta {
 /* @Indexed */
 message Job {
 
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string id = 1;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string processId = 2;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string processInstanceId = 3;
-    /* @Field(store = Store.YES, indexNullAs = "__DEFAULT_NULL_TOKEN__") */
+    /* @Field(store = Store.YES, indexNullAs = "__DEFAULT_NULL_TOKEN__")
+     * @SortableField
+     */
     optional string rootProcessId = 4;
-    /* @Field(store = Store.YES, indexNullAs = "__DEFAULT_NULL_TOKEN__") */
+    /* @Field(store = Store.YES, indexNullAs = "__DEFAULT_NULL_TOKEN__")
+     * @SortableField
+     */
     optional string rootProcessInstanceId = 5;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional int64 expirationTime = 6;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional int32 priority = 7;
     optional string callbackEndpoint = 8;
     optional int64 repeatInterval = 9;
     optional int32 repeatLimit = 10;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string scheduledId = 11;
     optional int32 retries = 12;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional string status = 13;
-    /* @Field(store = Store.YES) */
+    /* @Field(store = Store.YES)
+     * @SortableField
+     */
     optional int64 lastUpdate = 14;
     optional int32 executionCounter = 15;
 


### PR DESCRIPTION
This fixed the issues on `InfinispanGraphQLQueryOrderByIT.testJobsSort`. I tried adding this annotation on all fields but in some cases didn't work, it is necessary to analyze the cause, I don't know how the data-index queries works, I mean all fields should be enabled to be sorted?...

